### PR TITLE
更新单例 service 的实现逻辑

### DIFF
--- a/BeeHive/BHServiceProtocol.h
+++ b/BeeHive/BHServiceProtocol.h
@@ -12,7 +12,7 @@
 
 @optional
 
-- (BOOL)singleton;
++ (BOOL)singleton;
 
 + (id)shareInstance;
 

--- a/Example/BeeHive/BHUserTrackViewController.m
+++ b/Example/BeeHive/BHUserTrackViewController.m
@@ -20,8 +20,7 @@
 
 @implementation BHUserTrackViewController
 
-
--(BOOL)singleton
++(BOOL)singleton
 {
     return NO;
 }


### PR DESCRIPTION
修改原因可见 [#71](https://github.com/alibaba/BeeHive/issues/71)，之前BHSeviceProtocol 中`+ (BOOL)singleton;` 和 `+ (id)shareInstance;` 都是无用状态，就算实现了，BH 也不会走这个逻辑。

我现在更改的是让 BeeHiveService 根据 BHServiceProtocol 中的逻辑来创建 service