### PR TITLE
修复#133<调用BHRouter.canOpenUrl过滤pathComponentKey为/无法转换为Class错误>

### DIFF
--- a/BeeHive.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/BeeHive.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/BeeHive/BHRouter.m
+++ b/BeeHive/BHRouter.m
@@ -254,6 +254,9 @@ static NSString *BHRURLGlobalScheme = nil;
             return;
         }
         NSString *pathComponentKey = subPaths.firstObject;
+        if([pathComponentKey isEqualToString:@"/"]) {
+            return;
+        }
         if (router.pathComponentByKey[pathComponentKey]) {
             return;
         }


### PR DESCRIPTION
详细内容见 issue #133 